### PR TITLE
feat(config): add external endpoint configs and service implementation

### DIFF
--- a/lampray-common/src/main/java/tech/lamprism/lampray/web/ExternalEndpointProvider.java
+++ b/lampray-common/src/main/java/tech/lamprism/lampray/web/ExternalEndpointProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023-2025 RollW
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.lamprism.lampray.web;
+
+/**
+ * Internal interface for inverting the dependency of the external endpoint
+ * provider. Since some components need to access the external endpoint
+ * without being aware of the web module.
+ *
+ * @author RollW
+ */
+public interface ExternalEndpointProvider {
+    /**
+     * Get the external web endpoint, which is used for accessing the web
+     * interface of the system.
+     * <p>
+     * See also: {@code ServerConfigKeys#HTTP_EXTERNAL_WEB_ADDRESS}
+     *
+     * @return the external web endpoint URL
+     */
+    String getExternalWebEndpoint();
+
+    /**
+     * Get the external API endpoint, which is used for accessing the API of
+     * the system.
+     * <p>
+     * See also: {@code ServerConfigKeys#HTTP_EXTERNAL_API_ADDRESS}
+     *
+     * @return the external API endpoint URL
+     */
+    String getExternalApiEndpoint();
+}

--- a/lampray-iam/authentication-api/src/main/java/tech/lamprism/lampray/security/firewall/filtertable/FilterTableFirewall.kt
+++ b/lampray-iam/authentication-api/src/main/java/tech/lamprism/lampray/security/firewall/filtertable/FilterTableFirewall.kt
@@ -57,7 +57,10 @@ class FilterTableFirewall(
         }
     }
 
-    private fun checkIp(ip: String): FirewallAccessResult {
+    private fun checkIp(ip: String?): FirewallAccessResult {
+        if (ip.isNullOrBlank()) {
+            return FirewallAccessResult.NEUTRAL
+        }
         val ipIdentifier = RequestIdentifier(ip, IdentifierType.IP)
         val filterEntry = filterTable[ipIdentifier] ?: return FirewallAccessResult.NEUTRAL
         return when (filterEntry.mode) {

--- a/lampray-iam/authentication-service/src/main/java/tech/lamprism/lampray/security/authentication/registration/service/OnUserRegistrationEventListener.java
+++ b/lampray-iam/authentication-service/src/main/java/tech/lamprism/lampray/security/authentication/registration/service/OnUserRegistrationEventListener.java
@@ -35,6 +35,10 @@ import tech.lamprism.lampray.security.authentication.VerifiableToken;
 import tech.lamprism.lampray.security.authentication.registration.OnUserRegistrationEvent;
 import tech.lamprism.lampray.security.authentication.registration.RegisterTokenProvider;
 import tech.lamprism.lampray.user.AttributedUser;
+import tech.lamprism.lampray.web.ExternalEndpointProvider;
+
+import java.io.IOException;
+import java.util.Properties;
 
 /**
  * @author RollW
@@ -46,13 +50,34 @@ public class OnUserRegistrationEventListener implements ApplicationListener<OnUs
     private final RegisterTokenProvider registerTokenProvider;
     private final PushMessageStrategyProvider pushMessageStrategyProvider;
     private final MailProperties mailProperties;
+    private final ExternalEndpointProvider externalEndpointProvider;
+
+    private final String activationUrl;
 
     public OnUserRegistrationEventListener(RegisterTokenProvider registerTokenProvider,
                                            MailProperties mailProperties,
-                                           PushMessageStrategyProvider pushMessageStrategyProvider) {
+                                           PushMessageStrategyProvider pushMessageStrategyProvider,
+                                           ExternalEndpointProvider externalEndpointProvider) {
         this.pushMessageStrategyProvider = pushMessageStrategyProvider;
         this.registerTokenProvider = registerTokenProvider;
         this.mailProperties = mailProperties;
+        this.externalEndpointProvider = externalEndpointProvider;
+        try {
+            this.activationUrl = loadActivationUrl();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load activation URL", e);
+        }
+    }
+
+    private String loadActivationUrl() throws IOException {
+        Properties urlProps = new Properties();
+        urlProps.load(OnUserRegistrationEventListener.class.getResourceAsStream("url.properties"));
+        String property = urlProps.getProperty("activation.url");
+        if (Strings.isNullOrEmpty(property)) {
+            throw new IOException("Activation URL is not configured in url.properties");
+        }
+
+        return property;
     }
 
     @Override
@@ -76,8 +101,9 @@ public class OnUserRegistrationEventListener implements ApplicationListener<OnUs
             return;
         }
         VerifiableToken registerToken = registerTokenProvider.createRegisterToken(user);
-        // TODO
-        String confirmUrl = "" + registerToken.token();
+        String activationUrl = this.activationUrl.replace("{token}", registerToken.token());
+
+        String confirmUrl = externalEndpointProvider.getExternalWebEndpoint() + activationUrl;
         // TODO: read email template
         PushMessageBody messageBody = new HtmlMessageBuilder()
                 .setTitle("[Lampray] Registration Confirmation")

--- a/lampray-iam/authentication-service/src/main/resources/tech/lamprism/lampray/security/authentication/registration/service/url.properties
+++ b/lampray-iam/authentication-service/src/main/resources/tech/lamprism/lampray/security/authentication/registration/service/url.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2023-2025 RollW
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# TODO: generate this file automatically by gradle
+activation.url=/user/register/activate/{token}
+

--- a/lampray-push/push-api/src/main/java/tech/lamprism/lampray/push/HtmlMessageBuilder.java
+++ b/lampray-push/push-api/src/main/java/tech/lamprism/lampray/push/HtmlMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 RollW
+ * Copyright (C) 2023-2025 RollW
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public class HtmlMessageBuilder implements PushMessageBuilder {
 
     @Override
     public PushMessageBuilder breakLine() {
-        content.append("<br />");
+        content.append("<br/>");
         return this;
     }
 

--- a/lampray-user/user-api/src/main/java/tech/lamprism/lampray/user/common/UserChecker.java
+++ b/lampray-user/user-api/src/main/java/tech/lamprism/lampray/user/common/UserChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 RollW
+ * Copyright (C) 2023-2025 RollW
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import java.util.regex.Pattern;
  * @author RollW
  */
 public class UserChecker {
-    public static final String USERNAME_REGEX = "^[a-zA-Z_\\-][\\w\\-]{3,20}$";
-    public static final String PASSWORD_REGEX = "^[A-Za-z\\d._\\-~!@#$^&*+=<>%;'\"\\\\\\/|()\\[\\]{}]{4,20}$";
+    public static final String USERNAME_REGEX = "^[a-zA-Z_\\-][\\w.\\-]{3,20}$";
+    public static final String PASSWORD_REGEX = "^[A-Za-z\\d._\\-~!@#$^&*+=<>%;'\"\\\\/|()\\[\\]{}]{4,20}$";
     public static final String EMAIL_REGEX = "^\\w+([-+.]\\w+)*@\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*$";
 
     private static final Pattern sUsernamePattern = Pattern.compile(USERNAME_REGEX);
@@ -34,9 +34,10 @@ public class UserChecker {
     private static final Pattern sEmailPattern = Pattern.compile(EMAIL_REGEX);
 
     /**
-     * Allow only letters, numbers, underscores and dash,
+     * Allow only letters, numbers, underscores, dash and dot,
      * length between 3 and 20,
-     * no special characters except underscore and dash.
+     * no special characters except underscore, dash and dot.
+     * Must start with a letter or underscore.
      */
     public static boolean checkUsername(String username) {
         if (StringUtils.isEmpty(username)) {

--- a/lampray-user/user-api/src/main/java/tech/lamprism/lampray/user/common/UserChecker.java
+++ b/lampray-user/user-api/src/main/java/tech/lamprism/lampray/user/common/UserChecker.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  * @author RollW
  */
 public class UserChecker {
-    public static final String USERNAME_REGEX = "^[a-zA-Z_\\-][\\w.\\-]{3,20}$";
+    public static final String USERNAME_REGEX = "^[a-zA-Z_\\-][\\w.\\-]{2,19}$";
     public static final String PASSWORD_REGEX = "^[A-Za-z\\d._\\-~!@#$^&*+=<>%;'\"\\\\/|()\\[\\]{}]{4,20}$";
     public static final String EMAIL_REGEX = "^\\w+([-+.]\\w+)*@\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*$";
 

--- a/lampray-web/src/main/java/tech/lamprism/lampray/server/AddressProvider.java
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/server/AddressProvider.java
@@ -150,7 +150,7 @@ public class AddressProvider implements ExternalEndpointProvider {
         Integer port = configReader.get(ServerConfigKeys.HTTP_PORT);
 
         String scheme = "http";
-        String hostname = StringUtils.isNoneEmpty(host) ? host : "localhost";
+        String hostname = StringUtils.isNotEmpty(host) ? host : "localhost";
         int actualPort = (port != null && port > 0) ? port : 5100;
 
         return buildAddress(scheme, hostname, actualPort);

--- a/lampray-web/src/main/java/tech/lamprism/lampray/server/AddressProvider.java
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/server/AddressProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2023-2025 RollW
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.lamprism.lampray.server;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import tech.lamprism.lampray.setting.ConfigReader;
+import tech.lamprism.lampray.setting.SettingSpecification;
+import tech.lamprism.lampray.web.ExternalEndpointProvider;
+import tech.lamprism.lampray.web.common.keys.ResourceConfigKeys;
+import tech.lamprism.lampray.web.common.keys.ServerConfigKeys;
+
+import java.time.Duration;
+
+/**
+ * Elegant address provider with automatic async support.
+ * Handles both sync and async scenarios transparently.
+ *
+ * @author RollW
+ */
+@Component
+public class AddressProvider implements ExternalEndpointProvider {
+    private static final Logger logger = LoggerFactory.getLogger(AddressProvider.class);
+
+    private final ConfigReader configReader;
+
+    // Thread-local storage for async context
+    private static final ThreadLocal<AsyncContext> asyncContext = new ThreadLocal<>();
+
+    // Simple cache for resolved addresses
+    private final Cache<String, String> cache = Caffeine.newBuilder()
+            .expireAfterAccess(Duration.ofMinutes(10))
+            .maximumSize(100)
+            .build();
+
+    public AddressProvider(ConfigReader configReader) {
+        this.configReader = configReader;
+    }
+
+    @Override
+    public String getExternalApiEndpoint() {
+        String configured = configReader.get(ServerConfigKeys.HTTP_EXTERNAL_API_ADDRESS);
+        if (StringUtils.isBlank(configured)) {
+            logger.debug("API external address not configured, using inherited.");
+            return resolveAddress(ServerConfigKeys.HTTP_EXTERNAL_API_ADDRESS, ServerConfigKeys.HTTP_EXTERNAL_ADDRESS_INHERITED);
+        }
+        return resolveAddress(ServerConfigKeys.HTTP_EXTERNAL_API_ADDRESS, configured);
+    }
+
+    @Override
+    public String getExternalWebEndpoint() {
+        if (Boolean.TRUE.equals(configReader.get(ResourceConfigKeys.FRONTEND_ENABLED))) {
+            // If frontend is enabled, web endpoint is same as API endpoint
+            return getExternalApiEndpoint();
+        }
+        String configured = configReader.get(ServerConfigKeys.HTTP_EXTERNAL_WEB_ADDRESS);
+        if (StringUtils.isEmpty(configured)) {
+            return getExternalApiEndpoint();
+        }
+        return resolveAddress(ServerConfigKeys.HTTP_EXTERNAL_WEB_ADDRESS, configured);
+    }
+
+    /**
+     * Resolve address with intelligent fallback and caching.
+     */
+    private String resolveAddress(SettingSpecification<String, String> configKey, String configured) {
+
+        // Use explicit configuration if provided
+        if (!ServerConfigKeys.HTTP_EXTERNAL_ADDRESS_INHERITED.equals(configured)) {
+            return normalizeAddress(configured);
+        }
+
+        // Try to resolve from context with caching
+        String cacheKey = configKey.getKey().getName() + "_" + getContextSignature();
+        String cached = cache.getIfPresent(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+
+        String resolved = resolveFromCurrentContext();
+        if (resolved == null) {
+            resolved = buildFallbackAddress();
+        }
+
+        cache.put(cacheKey, resolved);
+        return resolved;
+    }
+
+    /**
+     * Resolve address from current context (sync or async).
+     */
+    private String resolveFromCurrentContext() {
+        // Try current request context first (sync thread)
+        HttpServletRequest request = getCurrentRequest();
+        if (request != null) {
+            return buildAddress(request.getScheme(), request.getServerName(), request.getServerPort());
+        }
+
+        // Fallback to async context
+        AsyncContext context = asyncContext.get();
+        if (context != null) {
+            return buildAddress(context.scheme, context.host, context.port);
+        }
+
+        return null;
+    }
+
+    /**
+     * Build address from components.
+     */
+    private String buildAddress(String scheme, String host, int port) {
+        if (scheme == null || host == null) {
+            return null;
+        }
+
+        boolean isDefaultPort = ("http".equals(scheme) && port == 80) ||
+                ("https".equals(scheme) && port == 443);
+
+        return isDefaultPort ?
+                scheme + "://" + host :
+                scheme + "://" + host + ":" + port;
+    }
+
+    /**
+     * Build fallback address from configuration.
+     */
+    private String buildFallbackAddress() {
+        String host = configReader.get(ServerConfigKeys.HTTP_HOST);
+        Integer port = configReader.get(ServerConfigKeys.HTTP_PORT);
+
+        String scheme = "http";
+        String hostname = StringUtils.isNoneEmpty(host) ? host : "localhost";
+        int actualPort = (port != null && port > 0) ? port : 5100;
+
+        return buildAddress(scheme, hostname, actualPort);
+    }
+
+    /**
+     * Get current HTTP request from Spring context.
+     */
+    private HttpServletRequest getCurrentRequest() {
+        try {
+            ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            return attrs != null ? attrs.getRequest() : null;
+        } catch (IllegalStateException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Generate context signature for caching.
+     */
+    private String getContextSignature() {
+        HttpServletRequest request = getCurrentRequest();
+        if (request != null) {
+            return request.getScheme() + "_" + request.getServerName() + "_" + request.getServerPort();
+        }
+
+        AsyncContext context = asyncContext.get();
+        if (context != null) {
+            return context.scheme + "_" + context.host + "_" + context.port;
+        }
+
+        return "default";
+    }
+
+    /**
+     * Normalize address by removing trailing slash.
+     */
+    private String normalizeAddress(String address) {
+        if (address == null || address.isEmpty()) {
+            return "";
+        }
+        return address.endsWith("/") ? address.substring(0, address.length() - 1) : address;
+    }
+
+    /**
+     * Capture current request context for async use.
+     */
+    public AsyncContext captureContext() {
+        HttpServletRequest request = getCurrentRequest();
+        if (request != null) {
+            return new AsyncContext(
+                    request.getScheme(),
+                    request.getServerName(),
+                    request.getServerPort()
+            );
+        }
+        return null;
+    }
+
+    /**
+     * Set async context in current thread.
+     */
+    public void setAsyncContext(AsyncContext context) {
+        asyncContext.set(context);
+    }
+
+    /**
+     * Clear async context from current thread.
+     */
+    public void clearAsyncContext() {
+        asyncContext.remove();
+    }
+
+    /**
+     * Async context holder.
+     */
+    public static class AsyncContext {
+        final String scheme;
+        final String host;
+        final int port;
+
+        public AsyncContext(String scheme, String host, int port) {
+            this.scheme = scheme;
+            this.host = host;
+            this.port = port;
+        }
+
+        @Override
+        public String toString() {
+            return scheme + "://" + host + ":" + port;
+        }
+    }
+}

--- a/lampray-web/src/main/java/tech/lamprism/lampray/server/AddressProvider.java
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/server/AddressProvider.java
@@ -75,7 +75,7 @@ public class AddressProvider implements ExternalEndpointProvider {
             return getExternalApiEndpoint();
         }
         String configured = configReader.get(ServerConfigKeys.HTTP_EXTERNAL_WEB_ADDRESS);
-        if (StringUtils.isEmpty(configured)) {
+        if (StringUtils.isBlank(configured)) {
             return getExternalApiEndpoint();
         }
         return resolveAddress(ServerConfigKeys.HTTP_EXTERNAL_WEB_ADDRESS, configured);
@@ -189,7 +189,7 @@ public class AddressProvider implements ExternalEndpointProvider {
      * Normalize address by removing trailing slash.
      */
     private String normalizeAddress(String address) {
-        if (address == null || address.isEmpty()) {
+        if (StringUtils.isBlank(address)) {
             return "";
         }
         return address.endsWith("/") ? address.substring(0, address.length() - 1) : address;

--- a/lampray-web/src/main/java/tech/lamprism/lampray/system/database/DatabaseConfigKeys.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/system/database/DatabaseConfigKeys.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023-2025 RollW
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tech.lamprism.lampray.system.database
 
 import org.springframework.stereotype.Component
@@ -139,7 +155,7 @@ object DatabaseConfigKeys : SettingSpecificationSupplier {
      * Database character encoding for proper internationalization support.
      *
      * Ensures correct handling of international characters and emojis.
-     * Common values: utf8mb4 (MySQL), UTF8 (PostgreSQL), utf8 (general).
+     * Common values: utf8 (general).
      * Leave empty to use database server defaults.
      */
     @JvmField
@@ -147,7 +163,7 @@ object DatabaseConfigKeys : SettingSpecificationSupplier {
         .setDescription(
             SettingDescription.text(
                 "Database character encoding setting. Ensures correct handling of international " +
-                        "characters and emojis. Common values include utf8mb4 (MySQL), UTF8 (PostgreSQL), or utf8 (general). " +
+                        "characters and emojis. " +
                         "Leave empty to use database defaults."
             )
         )
@@ -176,7 +192,6 @@ object DatabaseConfigKeys : SettingSpecificationSupplier {
             )
         )
         .setSupportedSources(LOCAL_SOURCE)
-        .setDefaultValue("")
         .setRequired(false)
         .setAllowAnyValue(true)
         .build()

--- a/lampray-web/src/main/java/tech/lamprism/lampray/system/database/builders/AbstractDatabaseUrlBuilder.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/system/database/builders/AbstractDatabaseUrlBuilder.kt
@@ -72,7 +72,9 @@ abstract class AbstractDatabaseUrlBuilder : DatabaseUrlBuilder {
 
         // Add charset if specified
         config.charset?.let { charset ->
-            addCharsetParameter(params, charset)
+            if (charset.isNotBlank()) {
+                addCharsetParameter(params, charset)
+            }
         }
 
         // Add custom options

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/common/keys/ResourceConfigKeys.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/common/keys/ResourceConfigKeys.kt
@@ -38,7 +38,7 @@ object ResourceConfigKeys : SettingSpecificationSupplier {
                 Enable frontend resource hosting.
                 """.trimIndent())
             .setDefaultValue(false)
-            .setSupportedSources(SettingSource.LOCAL_ONLY)
+            .setSupportedSources(SettingSource.VALUES)
             .setRequired(false)
             .build()
 
@@ -51,7 +51,7 @@ object ResourceConfigKeys : SettingSpecificationSupplier {
                 Note: If self-hosting is not enabled, this configuration will be ignored.
                 """.trimIndent())
             .setDefaultValue(EMBEDDED_RESOURCE)
-            .setSupportedSources(SettingSource.LOCAL_ONLY)
+            .setSupportedSources(SettingSource.VALUES)
             .setRequired(false)
             .build()
 

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/common/keys/ServerConfigKeys.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/common/keys/ServerConfigKeys.kt
@@ -45,6 +45,41 @@ object ServerConfigKeys : SettingSpecificationSupplier {
             .setRequired(false)
             .build()
 
+    const val HTTP_EXTERNAL_ADDRESS_INHERITED = "[inherited]"
+
+    @JvmField
+    val HTTP_EXTERNAL_API_ADDRESS =
+        SettingSpecificationBuilder(SettingKey.ofString("server.http.external.api.address"))
+            .setTextDescription(
+                "HTTP server external api address, the address will be used to generate api links.\n\n" +
+                        "If set to ${HTTP_EXTERNAL_ADDRESS_INHERITED}, the server will try to infer the address from the request, and " +
+                        "not recommend for production use as it may cause issues when access from different addresses. " +
+                        "Needs to be a full URL, e.g. https://api.example.com . " +
+                        "This config has no effect on http server configs."
+            )
+            .setDefaultValue(HTTP_EXTERNAL_ADDRESS_INHERITED)
+            .setAllowAnyValue(true)
+            .setSupportedSources(SettingSource.VALUES)
+            .setRequired(true)
+            .build()
+
+    @JvmField
+    val HTTP_EXTERNAL_WEB_ADDRESS =
+        SettingSpecificationBuilder(SettingKey.ofString("server.http.external.web.address"))
+            .setTextDescription(
+                "HTTP server external web address, when enabled frontend resource hosting will ignore this address " +
+                        "and use the same address as 'server.http.external.api.address'.\n\n" +
+                        "If set to ${HTTP_EXTERNAL_ADDRESS_INHERITED}, the server will try to infer the address from the request, and " +
+                        "not recommend for production use as it may cause issues when access from different addresses. " +
+                        "Needs to be a full URL, e.g. https://api.example.com . " +
+                        "This config has no effect on http server configs."
+            )
+            .setDefaultValue(HTTP_EXTERNAL_ADDRESS_INHERITED)
+            .setAllowAnyValue(true)
+            .setSupportedSources(SettingSource.VALUES)
+            .setRequired(true)
+            .build()
+
     @JvmField
     val PROCESS_PROXY_HEADERS =
         SettingSpecificationBuilder(SettingKey.ofBoolean("server.http.process-proxy-headers"))

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/common/keys/ServerConfigKeys.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/common/keys/ServerConfigKeys.kt
@@ -124,7 +124,9 @@ object ServerConfigKeys : SettingSpecificationSupplier {
             .build()
 
     private val keys = listOf(
-        HTTP_PORT, HTTP_HOST, PROCESS_PROXY_HEADERS, SSH_PORT, SSH_HOST, SSH_HOST_KEY
+        HTTP_PORT, HTTP_HOST, PROCESS_PROXY_HEADERS,
+        HTTP_EXTERNAL_API_ADDRESS, HTTP_EXTERNAL_WEB_ADDRESS,
+        SSH_PORT, SSH_HOST, SSH_HOST_KEY
     )
 
     override val specifications: List<AttributedSettingSpecification<*, *>>

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/configuration/AsyncConfiguration.java
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/configuration/AsyncConfiguration.java
@@ -56,8 +56,8 @@ public class AsyncConfiguration implements AsyncConfigurer {
     public ThreadPoolTaskExecutor mainScheduledExecutorService() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         int cpuCount = Runtime.getRuntime().availableProcessors();
-        executor.setCorePoolSize(Math.max(2, cpuCount * 2));
-        executor.setMaxPoolSize(Math.max(4, cpuCount * 4));
+        executor.setCorePoolSize(Math.max(2, Math.min(16, cpuCount * 2)));
+        executor.setMaxPoolSize(Math.max(4, Math.min(32, cpuCount * 4)));
         executor.setQueueCapacity(200);
         executor.setKeepAliveSeconds(120);
         executor.setThreadNamePrefix("async-main-");

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/configuration/AsyncConfiguration.java
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/configuration/AsyncConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 RollW
+ * Copyright (C) 2023-2025 RollW
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,18 @@
 
 package tech.lamprism.lampray.web.configuration;
 
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import space.lingu.NonNull;
+import tech.lamprism.lampray.server.AddressProvider;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -28,20 +35,66 @@ import java.util.concurrent.ThreadPoolExecutor;
  */
 @EnableAsync(proxyTargetClass = true)
 @Configuration
-public class AsyncConfiguration {
+public class AsyncConfiguration implements AsyncConfigurer {
+    private final AddressProvider addressProvider;
+
+    public AsyncConfiguration(AddressProvider addressProvider) {
+        this.addressProvider = addressProvider;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new SimpleAsyncUncaughtExceptionHandler();
+    }
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return mainScheduledExecutorService();
+    }
 
     @Bean
     public ThreadPoolTaskExecutor mainScheduledExecutorService() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(15);
-        executor.setMaxPoolSize(40);
-        executor.setQueueCapacity(500);
-        executor.setKeepAliveSeconds(20);
+        int cpuCount = Runtime.getRuntime().availableProcessors();
+        executor.setCorePoolSize(Math.max(2, cpuCount * 2));
+        executor.setMaxPoolSize(Math.max(4, cpuCount * 4));
+        executor.setQueueCapacity(200);
+        executor.setKeepAliveSeconds(120);
         executor.setThreadNamePrefix("async-main-");
+        executor.setTaskDecorator(new AddressContextTaskDecorator(addressProvider));
 
-        executor.setRejectedExecutionHandler(
-                new ThreadPoolExecutor.CallerRunsPolicy());
-        executor.initialize();
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         return executor;
     }
+
+    /**
+     * Task decorator that automatically manages address context.
+     */
+    private static class AddressContextTaskDecorator implements TaskDecorator {
+
+        private final AddressProvider addressProvider;
+
+        public AddressContextTaskDecorator(AddressProvider addressProvider) {
+            this.addressProvider = addressProvider;
+        }
+
+        @NonNull
+        @Override
+        public Runnable decorate(@NonNull Runnable runnable) {
+            // Capture context in the calling thread
+            AddressProvider.AsyncContext context = addressProvider.captureContext();
+
+            return () -> {
+                if (context != null) {
+                    addressProvider.setAsyncContext(context);
+                }
+                try {
+                    runnable.run();
+                } finally {
+                    addressProvider.clearAsyncContext();
+                }
+            };
+        }
+    }
+
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the authentication, user, and web modules, focusing on external endpoint handling. The most significant change is the introduction of a unified external endpoint provider.

## Highlights

- Added the `ExternalEndpointProvider` interface to centralize access to external web and API endpoints, enabling components to retrieve endpoint URLs without direct dependency on the web module.
- Implemented `AddressProvider` as a concrete provider for external endpoints, with intelligent fallback, caching, and context-aware resolution for both synchronous and asynchronous scenarios.
- Refactored the registration confirmation flow: `OnUserRegistrationEventListener` now uses `ExternalEndpointProvider` to construct activation URLs, loading the URL template from a new `url.properties` config file and replacing the token dynamically.
- Other code improvements and bug fixes.