### PR TITLE
feat(setting): refactor config listing and implement RESTful API

### DIFF
--- a/lampray-content/content-service/src/main/java/tech/lamprism/lampray/content/service/ContentService.java
+++ b/lampray-content/content-service/src/main/java/tech/lamprism/lampray/content/service/ContentService.java
@@ -48,9 +48,7 @@ import tech.lamprism.lampray.content.persistence.ContentMetadataRepository;
 import tech.lamprism.lampray.content.publish.ContentPublishListener;
 import tech.rollw.common.web.CommonErrorCode;
 import tech.rollw.common.web.ErrorCode;
-import tech.rollw.common.web.system.ContextThreadAware;
 import tech.rollw.common.web.system.UnsupportedKindException;
-import tech.rollw.common.web.system.paged.PageableContext;
 
 import java.time.OffsetDateTime;
 import java.util.Collection;
@@ -72,7 +70,6 @@ public class ContentService implements ContentAccessService,
     private final ContentProviderFactory contentProviderFactory;
     private final ContentPermitChecker contentPermitChecker;
     private final ContentMetadataRepository contentMetadataRepository;
-    private final ContextThreadAware<PageableContext> pageableContextThreadAware;
 
     public ContentService(List<ContentPublisher> contentPublishers,
                           List<UncreatedContentPreChecker> uncreatedContentPreCheckers,
@@ -80,8 +77,7 @@ public class ContentService implements ContentAccessService,
                           List<ContentPublishListener> contentPublishListeners,
                           ContentProviderFactory contentProviderFactory,
                           ContentPermitChecker contentPermitChecker,
-                          ContentMetadataRepository contentMetadataRepository,
-                          ContextThreadAware<PageableContext> pageableContextThreadAware) {
+                          ContentMetadataRepository contentMetadataRepository) {
         this.contentPublishers = contentPublishers;
         this.uncreatedContentPreCheckers = uncreatedContentPreCheckers;
         this.contentCollectionProviders = contentCollectionProviders;
@@ -89,7 +85,6 @@ public class ContentService implements ContentAccessService,
         this.contentProviderFactory = contentProviderFactory;
         this.contentPermitChecker = contentPermitChecker;
         this.contentMetadataRepository = contentMetadataRepository;
-        this.pageableContextThreadAware = pageableContextThreadAware;
     }
 
     /**

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigReader.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigReader.kt
@@ -38,7 +38,12 @@ interface ConfigReader {
 
     fun <T, V> getValue(specification: SettingSpecification<T, V>): ConfigValue<T, V>
 
-    fun list(): List<RawSettingValue>
+    /**
+     * Get multiple config values by specifications.
+     *
+     * Note: The order of the returned list is the same as the order of the input specifications.
+     */
+    fun list(specifications: List<SettingSpecification<*, *>>): List<ConfigValue<*, *>>
 
     /**
      * Metadata of the config reader.

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigValue.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigValue.kt
@@ -19,11 +19,13 @@ package tech.lamprism.lampray.setting
 /**
  * @author RollW
  */
-interface ConfigValue<T, V> : SettingSpecification<T, V> {
+interface ConfigValue<T, V> {
     val value: T?
 
     /**
      * The source of current value from.
      */
     val source: SettingSource
+
+    val specification: SettingSpecification<T, V>
 }

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigValueInfo.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigValueInfo.kt
@@ -16,6 +16,7 @@
 
 package tech.lamprism.lampray.setting
 
+import tech.lamprism.lampray.TimeAttributed
 import tech.lamprism.lampray.setting.SettingSpecification.Companion.keyName
 import java.time.OffsetDateTime
 
@@ -54,7 +55,12 @@ data class ConfigValueInfo<T, V>(
      * The last modified time of this config if available.
      */
     val lastModified: OffsetDateTime?
-) : ConfigValue<T, V> {
+) : ConfigValue<T, V>, TimeAttributed {
+    override fun getCreateTime(): OffsetDateTime =
+        TimeAttributed.NONE_TIME
+
+    override fun getUpdateTime(): OffsetDateTime =
+        lastModified ?: TimeAttributed.NONE_TIME
 
     companion object {
         @JvmStatic

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigValueInfo.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigValueInfo.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 RollW
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.lamprism.lampray.setting
+
+import tech.lamprism.lampray.setting.SettingSpecification.Companion.keyName
+import java.time.OffsetDateTime
+
+/**
+ * Config information including metadata and value details.
+ *
+ * @author RollW
+ */
+data class ConfigValueInfo<T, V>(
+    /**
+     * The setting specification that defines the config key and type.
+     */
+    override val specification: SettingSpecification<T, V>,
+
+    /**
+     * The raw key string.
+     */
+    val key: String,
+
+    /**
+     * The current value of the config.
+     */
+    override val value: T?,
+
+    /**
+     * The raw value as stored in the source in its string form.
+     */
+    val rawValue: String?,
+
+    /**
+     * The source where this config value comes from.
+     */
+    override val source: SettingSource,
+
+    /**
+     * The last modified time of this config if available.
+     */
+    val lastModified: OffsetDateTime?
+) : ConfigValue<T, V> {
+
+    companion object {
+        @JvmStatic
+        fun <T, V> from(
+            specification: SettingSpecification<T, V>,
+            value: T?,
+            rawValue: String?,
+            source: SettingSource,
+            lastModified: OffsetDateTime?
+        ): ConfigValueInfo<T, V> {
+            return ConfigValueInfo(
+                specification = specification,
+                key = specification.keyName,
+                value = value,
+                rawValue = rawValue,
+                source = source,
+                lastModified = lastModified
+            )
+        }
+    }
+}

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigWriter.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/ConfigWriter.kt
@@ -50,7 +50,7 @@ interface ConfigWriter {
      * or [SettingSource.NONE] if the value is not stored.
      */
     fun <T, V> set(configValue: ConfigValue<T, V>): SettingSource {
-        return set(configValue, configValue.value)
+        return set(configValue.specification, configValue.value)
     }
 
     fun supports(spec: SettingSpecification<*, *>): Boolean {

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/EnvironmentConfigReader.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/EnvironmentConfigReader.kt
@@ -69,8 +69,8 @@ class EnvironmentConfigReader(
         }
     }
 
-    override fun list(): List<RawSettingValue> {
-        return emptyList()
+    override fun list(specifications: List<SettingSpecification<*, *>>): List<ConfigValue<*, *>> {
+        return specifications.map { getValue(it) }
     }
 
     private fun String.asEnvKey(): String {

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/SecretLevel.java
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/SecretLevel.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023-2025 RollW
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.lamprism.lampray.setting;
+
+/**
+ * @author RollW
+ */
+public enum SecretLevel {
+    /**
+     * No masking, the value is returned as is.
+     */
+    NONE {
+        @Override
+        public String maskValue(String value) {
+            return value;
+        }
+    },
+
+    /**
+     * Low masking, the center part of the string is masked with '*'.
+     */
+    LOW {
+        @Override
+        public String maskValue(String value) {
+            if (value == null || value.isEmpty()) {
+                return "*";
+            }
+
+            // mask the center part of the string
+            int length = value.length();
+            int maskLength = Math.max(1, length / 2);
+            int start = (length - maskLength) / 2;
+            StringBuilder maskedValue = new StringBuilder(value);
+            for (int i = start; i < start + maskLength; i++) {
+                maskedValue.setCharAt(i, '*');
+            }
+            return maskedValue.toString();
+        }
+    },
+
+    /**
+     * Medium masking, the entire string is masked with '*'.
+     */
+    MEDIUM {
+        @Override
+        public String maskValue(String value) {
+            if (value == null || value.isEmpty()) {
+                return "*";
+            }
+            return "*".repeat(value.length());
+        }
+    },
+
+    /**
+     * High masking, only 4 '*' characters are returned, regardless of the input string length.
+     */
+    HIGH {
+        @Override
+        public String maskValue(String value) {
+            return "*".repeat(4);
+        }
+    };
+
+    /**
+     * Masks the given value based on the secret level.
+     *
+     * @param value the value to be masked
+     * @return the masked value
+     */
+    public abstract String maskValue(String value);
+
+    public String maskValue(ConfigValue<?, ?> value) {
+        if (value == null) {
+            return null;
+        }
+        Object v = value.getValue();
+        if (v == null) {
+            return null;
+        }
+        return maskValue(String.valueOf(v));
+    }
+}

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/SettingSpecificationBuilder.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/SettingSpecificationBuilder.kt
@@ -53,48 +53,49 @@ class SettingSpecificationBuilder<T, V> {
 
     var valueEntries: List<V?> = emptyList()
         private set
-    
+
     var secret: Boolean = false
         private set
 
-    fun setKey(key: SettingKey<T, V>) = apply{
+    fun setKey(key: SettingKey<T, V>) = apply {
         this.key = key
     }
 
-    fun setDescription(description: SettingDescription) = apply{
+    fun setDescription(description: SettingDescription) = apply {
         this.description = description
     }
 
-    fun setTextDescription(description: String) = apply{
+    fun setTextDescription(description: String) = apply {
         this.description = SettingDescription.text(description)
     }
 
-    fun setResourceDescription(key: String) = apply{
+    fun setResourceDescription(key: String) = apply {
         this.description = SettingDescription.resource(key)
     }
 
-    fun setAllowAnyValue(allowAnyValue: Boolean) = apply{
+    fun setAllowAnyValue(allowAnyValue: Boolean) = apply {
         this.allowAnyValue = allowAnyValue
     }
 
-    fun setSupportedSources(supportedSources: List<SettingSource>) = apply{
+    fun setSupportedSources(supportedSources: List<SettingSource>) = apply {
         this.supportedSources = supportedSources
     }
 
-    fun setRequired(isRequired: Boolean) = apply{
+    fun setRequired(isRequired: Boolean) = apply {
         this.isRequired = isRequired
     }
 
-    fun setDefaults(defaults: List<Int>) = apply{
+    fun setDefaults(defaults: List<Int>) = apply {
         this.defaults = defaults
     }
 
-    fun setDefault(default: Int) = apply{
+    fun setDefault(default: Int) = apply {
         this.defaults = listOf(default)
     }
 
-    fun setDefaultValue(default: V?) = apply{
+    fun setDefaultValue(default: V?) = apply {
         if (valueEntries.isNotEmpty()) {
+            // TODO: fix default value setting
             if (default != null && !valueEntries.contains(default)) {
                 throw IllegalArgumentException("Default value $default is not in the value entries $valueEntries")
             }
@@ -107,10 +108,10 @@ class SettingSpecificationBuilder<T, V> {
         this.valueEntries = listOf(default)
     }
 
-    fun setValueEntries(valueEntries: List<V?>) = apply{
+    fun setValueEntries(valueEntries: List<V?>) = apply {
         this.valueEntries = valueEntries
     }
-    
+
     fun setSecret(secret: Boolean) = apply {
         this.secret = secret
     }

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/SettingSpecificationHelper.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/SettingSpecificationHelper.kt
@@ -26,14 +26,14 @@ object SettingSpecificationHelper {
             return null
         }
         return when (specification.key.type) {
-            SettingType.STRING -> this as T
-            SettingType.INT -> this.toInt() as T
-            SettingType.LONG -> this.toLong() as T
-            SettingType.FLOAT -> this.toFloat() as T
-            SettingType.DOUBLE -> this.toDouble() as T
-            SettingType.BOOLEAN -> this.toBoolean() as T
+            SettingType.STRING -> this as T?
+            SettingType.INT -> this.toIntOrNull() as T?
+            SettingType.LONG -> this.toLongOrNull() as T?
+            SettingType.FLOAT -> this.toFloatOrNull() as T?
+            SettingType.DOUBLE -> this.toDoubleOrNull() as T?
+            SettingType.BOOLEAN -> this.toBoolean() as T?
             // TODO: implement a better way to deserialize set
-            SettingType.STRING_SET -> this.split(",").toSet() as T
+            SettingType.STRING_SET -> this.split(",").toSet() as T?
             else -> throw IllegalArgumentException("Unsupported type: $this")
         }
     }

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/SnapshotConfigValue.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/SnapshotConfigValue.kt
@@ -26,9 +26,9 @@ import tech.lamprism.lampray.setting.SettingSpecification.Companion.keyName
 data class SnapshotConfigValue<T, V>(
     override val value: T?,
     override val source: SettingSource,
-    private val settingSpecification: SettingSpecification<T, V>
-) : ConfigValue<T, V>, SettingSpecification<T, V> by settingSpecification {
+    override val specification: SettingSpecification<T, V>
+) : ConfigValue<T, V>, SettingSpecification<T, V> by specification {
     override fun toString(): String {
-        return "SnapshotConfigValue[${settingSpecification.keyName}](value=$value, source=$source)"
+        return "SnapshotConfigValue[${specification.keyName}](value=$value, source=$source)"
     }
 }

--- a/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/TomlConfigReader.kt
+++ b/lampray-system/setting-api/src/main/java/tech/lamprism/lampray/setting/TomlConfigReader.kt
@@ -167,32 +167,8 @@ class TomlConfigReader(
         return SnapshotConfigValue(value, SettingSource.LOCAL, specification)
     }
 
-    override fun list(): List<RawSettingValue> {
-        return flattenMap(values)
-    }
-
-    private fun flattenMap(
-        map: Map<String, Any>,
-        prefix: String = ""
-    ): List<RawSettingValue> {
-        val result = mutableListOf<RawSettingValue>()
-        for ((key, value) in map) {
-            val fullKey = if (prefix.isEmpty()) key else "$prefix.$key"
-            when (value) {
-                is Map<*, *> -> {
-                    result.addAll(flattenMap(value as Map<String, Any>, fullKey))
-                }
-
-                is String -> {
-                    result.add(RawSettingValue(fullKey, value, SettingSource.LOCAL))
-                }
-
-                else -> {
-                    result.add(RawSettingValue(fullKey, value.toString(), SettingSource.LOCAL))
-                }
-            }
-        }
-        return result
+    override fun list(specifications: List<SettingSpecification<*, *>>): List<ConfigValue<*, *>> {
+        return specifications.map { getValue(it) }
     }
 
     companion object {

--- a/lampray-system/setting-service/src/main/java/tech/lamprism/lampray/setting/data/SystemSettingDao.kt
+++ b/lampray-system/setting-service/src/main/java/tech/lamprism/lampray/setting/data/SystemSettingDao.kt
@@ -16,7 +16,6 @@
 
 package tech.lamprism.lampray.setting.data
 
-import org.springframework.data.jpa.repository.Query
 import tech.lamprism.lampray.common.data.CommonDao
 import tech.lamprism.lampray.common.data.Dao
 
@@ -25,6 +24,4 @@ import tech.lamprism.lampray.common.data.Dao
  */
 @Dao
 interface SystemSettingDao: CommonDao<SystemSettingDo, Long> {
-    @Query("SELECT s FROM SystemSettingDo s WHERE s.key = :key")
-    fun findByKey(key: String): SystemSettingDo?
 }

--- a/lampray-system/setting-service/src/main/java/tech/lamprism/lampray/setting/data/SystemSettingDo.kt
+++ b/lampray-system/setting-service/src/main/java/tech/lamprism/lampray/setting/data/SystemSettingDo.kt
@@ -22,6 +22,8 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import jakarta.persistence.Temporal
+import jakarta.persistence.TemporalType
 import jakarta.persistence.UniqueConstraint
 import tech.lamprism.lampray.DataEntity
 import tech.lamprism.lampray.TimeAttributed
@@ -46,7 +48,11 @@ class SystemSettingDo(
     var key: String = "",
 
     @Column(name = "value")
-    var value: String? = null
+    var value: String? = null,
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "update_time", nullable = false)
+    private var updateTime: OffsetDateTime = OffsetDateTime.now()
 ) : DataEntity<Long> {
     override fun getId(): Long? = id
 
@@ -54,9 +60,13 @@ class SystemSettingDo(
         this.id = id
     }
 
+    fun setUpdateTime(updateTime: OffsetDateTime) {
+        this.updateTime = updateTime
+    }
+
     override fun getCreateTime(): OffsetDateTime = TimeAttributed.NONE_TIME
 
-    override fun getUpdateTime(): OffsetDateTime = TimeAttributed.NONE_TIME
+    override fun getUpdateTime(): OffsetDateTime = updateTime
 
     override fun getSystemResourceKind(): SystemResourceKind =
         SystemSettingResourceKind

--- a/lampray-system/setting-service/src/main/java/tech/lamprism/lampray/setting/data/SystemSettingRepository.kt
+++ b/lampray-system/setting-service/src/main/java/tech/lamprism/lampray/setting/data/SystemSettingRepository.kt
@@ -18,6 +18,7 @@ package tech.lamprism.lampray.setting.data
 
 import org.springframework.stereotype.Repository
 import tech.lamprism.lampray.common.data.CommonRepository
+import java.util.Optional
 
 /**
  * @author RollW
@@ -26,7 +27,18 @@ import tech.lamprism.lampray.common.data.CommonRepository
 class SystemSettingRepository(
     private val systemSettingDao: SystemSettingDao
 ) : CommonRepository<SystemSettingDo, Long>(systemSettingDao) {
-    fun findByKey(key: String): SystemSettingDo? {
-        return systemSettingDao.findByKey(key)
+    fun findByKey(key: String): Optional<SystemSettingDo> {
+        return findOne { root, query, criteriaBuilder ->
+            criteriaBuilder.equal(root.get<String>("key"), key)
+        }
+    }
+
+    fun findByKeyIn(keys: Set<String>): List<SystemSettingDo> {
+        if (keys.isEmpty()) {
+            return emptyList()
+        }
+        return findAll { root, query, criteriaBuilder ->
+            root.get<String>("key").`in`(keys)
+        }
     }
 }

--- a/lampray-system/setting-service/src/main/java/tech/lamprism/lampray/setting/service/SystemSettingConfigProvider.kt
+++ b/lampray-system/setting-service/src/main/java/tech/lamprism/lampray/setting/service/SystemSettingConfigProvider.kt
@@ -21,7 +21,7 @@ import tech.lamprism.lampray.setting.ConfigPath
 import tech.lamprism.lampray.setting.ConfigProvider
 import tech.lamprism.lampray.setting.ConfigReader
 import tech.lamprism.lampray.setting.ConfigValue
-import tech.lamprism.lampray.setting.RawSettingValue
+import tech.lamprism.lampray.setting.ConfigValueInfo
 import tech.lamprism.lampray.setting.SettingSource
 import tech.lamprism.lampray.setting.SettingSpecification
 import tech.lamprism.lampray.setting.SettingSpecification.Companion.keyName
@@ -42,12 +42,13 @@ class SystemSettingConfigProvider(
 
     override val metadata: ConfigReader.Metadata =
         ConfigReader.Metadata(
-           name =  "SystemSettingConfigProvider",
+            name = "SystemSettingConfigProvider",
             paths = listOf(ConfigPath("system_setting", SettingSource.DATABASE)),
         )
 
     override fun get(key: String): String? {
-        return systemSettingRepository.findByKey(key)?.value
+        return systemSettingRepository.findByKey(key)
+            .orElse(null)?.value
     }
 
     override fun get(key: String, defaultValue: String?): String? =
@@ -55,7 +56,7 @@ class SystemSettingConfigProvider(
 
     override fun <T, V> get(specification: SettingSpecification<T, V>): T? {
         val setting = systemSettingRepository.findByKey(specification.keyName)
-            ?: return null
+            .orElse(null) ?: return null
         return with(SettingSpecificationHelper) {
             setting.value.deserialize(specification)
         }
@@ -68,7 +69,7 @@ class SystemSettingConfigProvider(
 
     override fun <T, V> getValue(specification: SettingSpecification<T, V>): ConfigValue<T, V> {
         val setting = systemSettingRepository.findByKey(specification.keyName)
-            ?: return SnapshotConfigValue(null, SettingSource.NONE, specification)
+            .orElse(null) ?: return SnapshotConfigValue(null, SettingSource.NONE, specification)
         return with(SettingSpecificationHelper) {
             SnapshotConfigValue(
                 setting.value.deserialize(specification),
@@ -78,18 +79,31 @@ class SystemSettingConfigProvider(
         }
     }
 
-    override fun list(): List<RawSettingValue> {
-        return systemSettingRepository.findAll().map {
-            RawSettingValue(
-                it.key,
-                it.value,
-                SettingSource.DATABASE
-            )
+    override fun list(specifications: List<SettingSpecification<*, *>>): List<ConfigValue<*, *>> {
+        if (specifications.isEmpty()) {
+            return emptyList()
+        }
+        val keys = specifications.map { it.keyName }.toSet()
+        val settings = systemSettingRepository.findByKeyIn(keys)
+            .associateBy { it.key }
+        @Suppress("UNCHECKED_CAST")
+        return (specifications as List<SettingSpecification<Any, Any>>).map { spec ->
+            val setting = settings[spec.keyName] ?: return@map SnapshotConfigValue(null, SettingSource.NONE, spec)
+            with(SettingSpecificationHelper) {
+                ConfigValueInfo.from(
+                    specification = spec,
+                    value = setting.value.deserialize(spec),
+                    source = SettingSource.DATABASE,
+                    rawValue = setting.value,
+                    lastModified = setting.updateTime
+                )
+            }
         }
     }
 
     override fun set(key: String, value: String?): SettingSource {
         val setting = systemSettingRepository.findByKey(key)
+            .orElse(null)
         if (setting != null) {
             setting.value = value
             systemSettingRepository.save(setting)
@@ -105,6 +119,7 @@ class SystemSettingConfigProvider(
 
     override fun <T, V> set(spec: SettingSpecification<T, V>, value: T?): SettingSource {
         val setting = systemSettingRepository.findByKey(spec.keyName)
+            .orElse(null)
         val value = with(SettingSpecificationHelper) {
             value.serialize(spec)
         }

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/configuration/filter/CorsConfigFilter.java
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/configuration/filter/CorsConfigFilter.java
@@ -24,6 +24,7 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.NestedRuntimeException;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
@@ -46,7 +47,15 @@ public class CorsConfigFilter implements Filter {
         try {
             chain.doFilter(request, response);
         } catch (Exception e) {
-            resolver.resolveException(request, response, null, e);
+            Exception exception = e;
+            if (exception instanceof ServletException se && se.getRootCause() != null) {
+                exception = (Exception) se.getRootCause();
+            }
+            if (exception instanceof NestedRuntimeException nre && nre.getRootCause() != null) {
+                exception = (Exception) nre.getRootCause();
+            }
+
+            resolver.resolveException(request, response, null, exception);
         }
     }
 

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/SystemSettingController.java
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/SystemSettingController.java
@@ -16,15 +16,16 @@
 
 package tech.lamprism.lampray.web.controller.system;
 
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import tech.lamprism.lampray.TimeAttributed;
 import tech.lamprism.lampray.setting.AttributedSettingSpecification;
 import tech.lamprism.lampray.setting.ConfigProvider;
 import tech.lamprism.lampray.setting.ConfigValue;
-import tech.lamprism.lampray.setting.ConfigValueInfo;
 import tech.lamprism.lampray.setting.SecretLevel;
 import tech.lamprism.lampray.setting.SettingDescriptionProvider;
 import tech.lamprism.lampray.setting.SettingKey;
@@ -68,7 +69,7 @@ public class SystemSettingController {
 
     @GetMapping("/system/settings")
     public HttpResponseEntity<List<SettingVo>> getSettings(
-            ListSettingRequest listSettingRequest
+           @Valid ListSettingRequest listSettingRequest
     ) {
         List<AttributedSettingSpecification<?, ?>> specifications = settingSpecificationProvider.getSettingSpecifications();
         List<AttributedSettingSpecification<?, ?>> settingSpecifications = filterSpecifications(
@@ -117,14 +118,14 @@ public class SystemSettingController {
         SettingKey<?, ?> key = value.getSpecification().getKey();
         Object masked = maskSecret(value.getValue(), secretLevel);
         String description = settingDescriptionProvider.getSettingDescription(specification.getDescription());
-        if (value instanceof ConfigValueInfo<?, ?> info) {
+        if (value instanceof TimeAttributed timeAttributed) {
             return new SettingVo(
                     key.getName(),
                     masked,
                     description,
                     key.getType().toString(),
                     value.getSource(),
-                    info.getLastModified()
+                    timeAttributed.getUpdateTime()
             );
         }
         return new SettingVo(

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/ListSettingRequest.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/ListSettingRequest.kt
@@ -7,4 +7,8 @@ data class ListSettingRequest(
     val page: Int = 1,
     val size: Int = 20,
 ) {
+    init {
+        require(page >= 1) { "Page must be greater than or equal to 1" }
+        require(size in 1..200) { "Size must be between 1 and 200" }
+    }
 }

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/ListSettingRequest.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/ListSettingRequest.kt
@@ -1,0 +1,10 @@
+package tech.lamprism.lampray.web.controller.system.model
+
+/**
+ * @author RollW
+ */
+data class ListSettingRequest(
+    val page: Int = 1,
+    val size: Int = 20,
+) {
+}

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/ListSettingRequest.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/ListSettingRequest.kt
@@ -1,10 +1,16 @@
 package tech.lamprism.lampray.web.controller.system.model
 
+import jakarta.validation.constraints.Min
+
 /**
  * @author RollW
  */
 data class ListSettingRequest(
+    @field:Min(value = 1, message = "Page must be greater than or equal to 1")
     val page: Int = 1,
+
+    @field:Min(value = 1, message = "Size must be between 1 and 200")
+    @field:Min(value = 200, message = "Size must be between 1 and 200")
     val size: Int = 20,
 ) {
     init {

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/SettingVo.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/SettingVo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 RollW
+ * Copyright (C) 2023 RollW
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,18 @@
  * limitations under the License.
  */
 
-package tech.lamprism.lampray.setting
+package tech.lamprism.lampray.web.controller.system.model
+
+import tech.lamprism.lampray.setting.SettingSource
 
 /**
  * @author RollW
  */
-class ReadonlyConfigProvider(
-    private val configReader: ConfigReader
-) : ConfigReader by configReader, ConfigProvider {
-    override fun set(key: String, value: String?) = SettingSource.NONE
-
-    override fun <T, V> set(spec: SettingSpecification<T, V>, value: T?) = SettingSource.NONE
-
-    override fun supports(key: String): Boolean = false
-
-    override val metadata: ConfigReader.Metadata
-        get() = configReader.metadata
-
-    val underlying: ConfigReader
-        get() = configReader
+data class SettingVo(
+    val key: String,
+    val value: String?,
+    val description: String,
+    val type: String,
+    val activeSource: SettingSource
+) {
 }

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/SettingVo.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/SettingVo.kt
@@ -24,7 +24,7 @@ import java.time.OffsetDateTime
  */
 data class SettingVo(
     val key: String,
-    val value: String?,
+    val value: Any?,
     val description: String,
     val type: String,
     val source: SettingSource,

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/SettingVo.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/system/model/SettingVo.kt
@@ -17,6 +17,7 @@
 package tech.lamprism.lampray.web.controller.system.model
 
 import tech.lamprism.lampray.setting.SettingSource
+import java.time.OffsetDateTime
 
 /**
  * @author RollW
@@ -26,6 +27,7 @@ data class SettingVo(
     val value: String?,
     val description: String,
     val type: String,
-    val activeSource: SettingSource
+    val source: SettingSource,
+    val updateTime: OffsetDateTime?
 ) {
 }

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/UserController.java
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/UserController.java
@@ -37,7 +37,6 @@ import tech.lamprism.lampray.web.controller.user.model.UserCommonDetailsVo;
 import tech.rollw.common.web.AuthErrorCode;
 import tech.rollw.common.web.HttpResponseEntity;
 import tech.rollw.common.web.system.ContextThreadAware;
-import tech.rollw.common.web.system.paged.PageableContext;
 
 import java.util.List;
 
@@ -47,20 +46,17 @@ import java.util.List;
 @Api
 public class UserController {
     private final ContextThreadAware<ApiContext> apiContextThreadAware;
-    private final ContextThreadAware<PageableContext> pageableContextThreadAware;
     private final UserProvider userProvider;
     private final UserSearchService userSearchService;
     private final UserPersonalDataService userPersonalDataService;
     private final StorageUrlProvider storageUrlProvider;
 
     public UserController(ContextThreadAware<ApiContext> apiContextThreadAware,
-                          ContextThreadAware<PageableContext> pageableContextThreadAware,
                           UserProvider userProvider,
                           UserSearchService userSearchService,
                           UserPersonalDataService userPersonalDataService,
                           StorageUrlProvider storageUrlProvider) {
         this.apiContextThreadAware = apiContextThreadAware;
-        this.pageableContextThreadAware = pageableContextThreadAware;
         this.userProvider = userProvider;
         this.userSearchService = userSearchService;
         this.userPersonalDataService = userPersonalDataService;


### PR DESCRIPTION
This pull request refactors the configuration and settings API to unify how configuration values are accessed, represented, and listed. The changes introduce a clearer separation between configuration specifications and their runtime values, improve extensibility and consistency in value retrieval, and enhance security through configurable secret masking.

## Highlights

- Introduced `ConfigValueInfo`, a new data class that encapsulates metadata, value, source, and last-modified timestamp, providing a consistent and extensible view of configuration values.
- Refactored `ConfigValue` to decouple from `SettingSpecification`, now requiring an explicit `specification` property—improving separation of concerns between definition and runtime value.
- Redesigned `ConfigReader.list()` to accept a list of `SettingSpecification` and return a correspondingly ordered list of `ConfigValue` instances, ensuring predictable and spec-aligned retrieval across providers.
- Added `SecretLevel` enum with strategies to mask sensitive values in both raw strings and `ConfigValue` objects, enhancing security observability.
- Implemented `SettingController` to expose configuration values via RESTful endpoints, enabling external systems to securely list and inspect settings with proper secret masking applied.

## Other Changes

- Enhanced type conversion and error handling in `SettingSpecificationHelper` for deserializing values.
- Minor cleanups and other bug fixes.