### PR TITLE
feat(auth)!: enhance registration token API with secure validation

### DIFF
--- a/lampray-iam/authentication-api/src/main/java/tech/lamprism/lampray/security/authentication/VerifiableToken.java
+++ b/lampray-iam/authentication-api/src/main/java/tech/lamprism/lampray/security/authentication/VerifiableToken.java
@@ -26,6 +26,11 @@ public interface VerifiableToken {
     String token();
 
     /**
+     * @return the user id associated with the token.
+     */
+    long getUserId();
+
+    /**
      * @return true if the token is usable.
      */
     boolean isUsable();

--- a/lampray-iam/authentication-api/src/main/java/tech/lamprism/lampray/security/authentication/registration/RegisterTokenProvider.java
+++ b/lampray-iam/authentication-api/src/main/java/tech/lamprism/lampray/security/authentication/registration/RegisterTokenProvider.java
@@ -26,6 +26,8 @@ import tech.rollw.common.web.CommonRuntimeException;
 public interface RegisterTokenProvider {
     VerifiableToken createRegisterToken(UserIdentity userIdentity);
 
+    VerifiableToken getRegisterToken(String token);
+
     void resendRegisterToken(UserIdentity user);
 
     void verifyRegisterToken(String token) throws CommonRuntimeException;

--- a/lampray-iam/authentication-service/src/main/java/tech/lamprism/lampray/security/authentication/registration/RegisterVerificationToken.java
+++ b/lampray-iam/authentication-service/src/main/java/tech/lamprism/lampray/security/authentication/registration/RegisterVerificationToken.java
@@ -35,7 +35,8 @@ public record RegisterVerificationToken(
         String token,
         long userId,
         long expiryTime,// timestamp
-        boolean used) implements VerifiableToken, DataEntity<Long> {
+        boolean used
+) implements VerifiableToken, DataEntity<Long> {
 
     public boolean isExpired() {
         return System.currentTimeMillis() > expiryTime;
@@ -90,6 +91,11 @@ public record RegisterVerificationToken(
 
     public RegisterVerificationToken markVerified() {
         return toBuilder().setUsed(true).build();
+    }
+
+    @Override
+    public long getUserId() {
+        return userId;
     }
 
     @Override

--- a/lampray-iam/authentication-service/src/main/java/tech/lamprism/lampray/security/authentication/registration/service/LoginRegisterService.java
+++ b/lampray-iam/authentication-service/src/main/java/tech/lamprism/lampray/security/authentication/registration/service/LoginRegisterService.java
@@ -248,6 +248,15 @@ public class LoginRegisterService implements LoginProvider, RegisterTokenProvide
     }
 
     @Override
+    public RegisterVerificationToken getRegisterToken(String token) {
+        RegisterTokenDo registerTokenDo = registerTokenRepository.findByToken(token);
+        if (registerTokenDo == null) {
+            throw new AuthenticationException(AuthErrorCode.ERROR_TOKEN_NOT_EXIST);
+        }
+        return registerTokenDo.lock();
+    }
+
+    @Override
     public void resendRegisterToken(UserIdentity user) {
         AttributedUser attributedUser = retrieveUser(user);
         OnUserRegistrationEvent event = new OnUserRegistrationEvent(

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/model/RegisterTokenInfoVo.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/model/RegisterTokenInfoVo.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023-2025 RollW
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tech.lamprism.lampray.web.controller.user.model
 
 import tech.lamprism.lampray.security.authentication.VerifiableToken

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/model/RegisterTokenInfoVo.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/model/RegisterTokenInfoVo.kt
@@ -1,0 +1,53 @@
+package tech.lamprism.lampray.web.controller.user.model
+
+import tech.lamprism.lampray.security.authentication.VerifiableToken
+import tech.lamprism.lampray.setting.SecretLevel
+import tech.lamprism.lampray.user.UserIdentity
+
+/**
+ * @author RollW
+ */
+data class RegisterTokenInfoVo(
+    val token: String,
+    val maskedUsername: String,
+    val maskedEmail: String,
+) {
+
+    companion object {
+        @JvmStatic
+        fun from(verifiableToken: VerifiableToken, userIdentity: UserIdentity): RegisterTokenInfoVo {
+            return RegisterTokenInfoVo(
+                token = verifiableToken.token(),
+                maskedUsername = maskUsername(userIdentity.username),
+                maskedEmail = maskEmail(userIdentity.email)
+            )
+        }
+
+        private fun maskUsername(username: String): String {
+            return SecretLevel.LOW.maskValue(username)
+        }
+
+        private fun maskEmail(email: String): String {
+            val atIndex = email.indexOf('@')
+            if (atIndex <= 0 || atIndex == email.length - 1) {
+                return SecretLevel.LOW.maskValue(email)
+            }
+            val name = email.take(atIndex)
+            val domainFull = email.substring(atIndex + 1)
+            val dotIndex = domainFull.indexOf('.')
+            val domain = if (dotIndex > 0) domainFull.take(dotIndex) else domainFull
+            val tld = if (dotIndex > 0) domainFull.substring(dotIndex + 1) else ""
+            val maskedName = if (name.length > 1) "${name.first()}***" else "***"
+            val maskedDomain = if (domain.length > 1) "${domain.first()}***" else "***"
+            return buildString {
+                append(maskedName)
+                append("@")
+                append(maskedDomain)
+                if (tld.isNotEmpty()) {
+                    append(".")
+                    append(tld)
+                }
+            }
+        }
+    }
+}

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/model/ResendRegisterTokenRequest.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/model/ResendRegisterTokenRequest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023-2025 RollW
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tech.lamprism.lampray.web.controller.user.model
 
 import jakarta.validation.constraints.NotEmpty

--- a/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/model/ResendRegisterTokenRequest.kt
+++ b/lampray-web/src/main/java/tech/lamprism/lampray/web/controller/user/model/ResendRegisterTokenRequest.kt
@@ -1,0 +1,14 @@
+package tech.lamprism.lampray.web.controller.user.model
+
+import jakarta.validation.constraints.NotEmpty
+
+/**
+ * @author RollW
+ */
+data class ResendRegisterTokenRequest(
+    @field:NotEmpty
+    val username: String,
+    @field:NotEmpty
+    val email: String,
+) {
+}


### PR DESCRIPTION
This pull request introduces a new API to retrieve registration token details and strengthens security by validating and masking sensitive user data.

## Highlights

- Added new endpoint `GET /register/token/{token}` to securely retrieve masked registration token info.
- The resend token endpoint now requires both username and email, and verifies that the email matches the user’s registered address before issuing a new token.

## Breaking Changes

- The resend registration token endpoint now requires both username and email, which may break existing clients that only provide one field.
